### PR TITLE
use more flexible chapter regex and refactoring

### DIFF
--- a/backend/src/main/java/com/fydp/backend/controllers/AppController.java
+++ b/backend/src/main/java/com/fydp/backend/controllers/AppController.java
@@ -39,7 +39,7 @@ public class AppController {
     private static final Logger logger = LoggerFactory.getLogger(AppController.class);
     private static final String UPLOAD_PATH = System.getProperty("user.dir") + "/upload_files/";
     private static final String END_OF_CHAPTER = "End of Last Chapter";
-    private static final String CHAPTER_REGEX = ".*\\d.*";
+    private static final String CHAPTER_REGEX = "(\\bchapter|\\bch|\\bch\\.|\\bchap|\\bchap\\.|\\bpart|\\bsection|^)\\s*\\d+";
 
     @Autowired
     private PdfInfo pdfInfo;

--- a/backend/src/main/java/com/fydp/backend/model/Bookmark.java
+++ b/backend/src/main/java/com/fydp/backend/model/Bookmark.java
@@ -1,0 +1,26 @@
+package com.fydp.backend.model;
+
+public class Bookmark {
+    private String title;
+    private int startPage;
+    private int endPage;
+    private int depth;
+
+    public Bookmark() {}
+
+    public Bookmark(String title, int startPage, int endPage, int depth) {
+        this.title = title;
+        this.startPage = startPage;
+        this.endPage = endPage;
+        this.depth = depth;
+    }
+
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+    public int getStartPage() { return startPage; }
+    public void setStartPage(int startPage) { this.startPage = startPage; }
+    public int getEndPage() { return endPage; }
+    public void setEndPage(int endPage) { this.endPage = endPage; }
+    public int getDepth() { return depth; }
+    public void setDepth(int depth) { this.depth = depth; }
+}

--- a/backend/src/main/java/com/fydp/backend/model/PdfInfo.java
+++ b/backend/src/main/java/com/fydp/backend/model/PdfInfo.java
@@ -7,8 +7,8 @@ import java.util.Map;
 
 @Component
 public class PdfInfo {
-    private Map<String, Integer> chapterPgMap;
-    private List<String> chapters;
+
+    private List<Bookmark> chapters;
     private String pdfText;
     private String fileName;
 
@@ -16,20 +16,12 @@ public class PdfInfo {
 
     }
 
-    public void setChapterPgMap(Map<String, Integer> chapterPgMap) {
-        this.chapterPgMap = chapterPgMap;
-    }
-
-    public Map<String, Integer> getChapterPgMap() {
-        return chapterPgMap;
-    }
-
-    public void setChapters(List<String> chapters) {
-        this.chapters = chapters;
-    }
-
-    public List<String> getChapters() {
+    public List<Bookmark> getChapters() {
         return chapters;
+    }
+
+    public void setChapters(List<Bookmark> chapters) {
+        this.chapters = chapters;
     }
 
     public void setPdfText(String pdfText) {

--- a/frontend/src/ChapterSelectorList.js
+++ b/frontend/src/ChapterSelectorList.js
@@ -19,15 +19,18 @@ class ChapterSelectorList extends React.Component {
 
   handleInputChange(e) {
     const target = e.target;
-    this.setState({ [target.name]: target.checked });
+    this.setState({ [target.id]: target.checked });
   }
 
   handleSubmit(e) {
     e.preventDefault();
 
     const selectedChapters = Object.entries(this.state)
-      .reduce((selected, [chapter, checked]) => {
-          if (checked) selected.push(chapter);
+      .reduce((selected, [chapId, checked]) => {
+          if (checked) {
+            const id = chapId.split('-')[1];
+            selected.push(this.props.location.state.data.chapters[id]);
+          }
           return selected;
       }, []);
 
@@ -46,10 +49,10 @@ class ChapterSelectorList extends React.Component {
     return chapters.map((chapter, index) =>
       <div className="chapter-selector-item" key={index}>
         <Form.Check
-          name={chapter}
+          name={chapter.title}
           id={`chapter-${index}`}
           type="checkbox"
-          label={chapter}
+          label={chapter.title}
           checked={this.state.chapter}
           onChange={this.handleInputChange}
         />


### PR DESCRIPTION
Currently, to detect chapters as candidates for summarization we use a regex to look for the word "Chapter". This PR makes it more flexible to allow more terms/variations as well as no term at all. It's impossible to accurately determine the chapters perfectly, but this should be good enough.

Also, if it doesn't find any chapters matching the format, it will simply return all the bookmarks instead of just giving up.

Overall, this should enable the PDF parser to parse more kinds of PDFs.

**Summary of changes**
* New chapter regex
* If no bookmarks match chapter regex, return all bookmarks
* Update page number retrieval from bookmark to be able to read more kinds of PDFs

**Regex testing**
Any highlight means it matched so last one is a false positive.

![image](https://user-images.githubusercontent.com/15786604/74680512-d6d96a00-518e-11ea-8a09-a0abd00eb954.png)
